### PR TITLE
Add Response import for SMS handler route

### DIFF
--- a/app/routes/sms_handler.py
+++ b/app/routes/sms_handler.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter, Response
+
+router = APIRouter()
+
+@router.post("/sms")
+def sms_handler() -> Response:
+    """Handle incoming SMS webhooks from Twilio."""
+    twiml_response = "<Response><Message>Hello from Swift!</Message></Response>"
+    return Response(content=twiml_response, media_type="application/xml")
+

--- a/main.py
+++ b/main.py
@@ -2,8 +2,10 @@ from fastapi import FastAPI
 from app.core.logging import setup_logging
 from app.middleware.request_id import RequestIdMiddleware
 from app.routes.http import router as http_router
+from app.routes.sms_handler import router as sms_router
 
 setup_logging()
 app = FastAPI(title="SWIFT Voice Service — Barge-In Ready")
 app.add_middleware(RequestIdMiddleware)
 app.include_router(http_router)
+app.include_router(sms_router)

--- a/tests/test_sms_handler.py
+++ b/tests/test_sms_handler.py
@@ -1,0 +1,20 @@
+import os
+import sys
+
+from fastapi.testclient import TestClient
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+os.environ.setdefault("SERVICE_AUTH_TOKEN", "test-token")
+
+from main import app
+
+client = TestClient(app)
+
+
+def test_sms_route_returns_twiml():
+    response = client.post("/sms")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/xml")
+    assert "<Response>" in response.text
+    assert "</Response>" in response.text
+


### PR DESCRIPTION
## Summary
- add SMS webhook handler with TwiML response using FastAPI Response
- wire SMS handler into main FastAPI app
- test SMS route returns expected TwiML XML

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba7b84e240833190dc697ed886b74b