### PR TITLE
Use in-memory buffer for Whisper transcription

### DIFF
--- a/app/services/transcription.py
+++ b/app/services/transcription.py
@@ -1,0 +1,28 @@
+from io import BytesIO
+from tempfile import NamedTemporaryFile
+from typing import Optional
+
+
+def transcribe_audio(data: bytes, model_name: str = "small") -> str:
+    """Transcribe audio bytes using faster-whisper.
+
+    The audio content is kept entirely in memory via :class:`io.BytesIO`
+    and passed directly to :meth:`WhisperModel.transcribe`.
+    """
+    from faster_whisper import WhisperModel
+
+    buffer = BytesIO(data)
+    model = WhisperModel(model_name)
+    segments, _ = model.transcribe(buffer)
+    return "".join(segment.text for segment in segments)
+
+
+def buffer_to_tempfile(buffer: BytesIO, suffix: str = ".wav") -> str:
+    """Persist a ``BytesIO`` buffer to a uniquely named temporary file.
+
+    Returns the file path so callers that still require a file on disk can
+    access the audio without clobbering other processes.
+    """
+    with NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+        tmp.write(buffer.getvalue())
+        return tmp.name

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ httpx
 twilio
 redis
 structlog
+faster-whisper


### PR DESCRIPTION
## Summary
- Transcribe uploaded audio directly from memory with BytesIO
- Provide helper to persist a BytesIO buffer to a uniquely named temp file
- Update requirements with faster-whisper dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba7cac34fc8331a3056485283dc683