### PR TITLE
Add Twilio request signature validation

### DIFF
--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -2,6 +2,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Settings(BaseSettings):
     SERVICE_AUTH_TOKEN: str
+    TWILIO_AUTH_TOKEN: str
     OPENAI_API_KEY: str | None = None
     REDIS_URL: str = "redis://localhost:6379/0"
     ENV: str = "local"

--- a/app/routes/http.py
+++ b/app/routes/http.py
@@ -1,32 +1,52 @@
 from fastapi import APIRouter, Header, HTTPException, Request
 from fastapi.responses import Response, JSONResponse
+from twilio.request_validator import RequestValidator
+
 from app.core.settings import settings
 from app.models.call import CallPayload
 from app.services.call_flow import build_initial_twiml, build_transcribe_twiml
 
+
 router = APIRouter()
+validator = RequestValidator(settings.TWILIO_AUTH_TOKEN)
+
+
+async def validate_twilio_request(request: Request) -> dict:
+    signature = request.headers.get("X-Twilio-Signature", "")
+    form = await request.form()
+    if not validator.validate(str(request.url), dict(form), signature):
+        raise HTTPException(status_code=403, detail="Invalid Twilio signature")
+    return dict(form)
+
 
 @router.get("/health")
-def health(): return {"ok": True}
+def health() -> dict:
+    return {"ok": True}
+
 
 @router.get("/ready")
-def ready(): return {"ok": True}
+def ready() -> dict:
+    return {"ok": True}
+
 
 @router.post("/process-call")
-def process_call(payload: CallPayload, x_service_token: str | None = Header(None)):
+def process_call(payload: CallPayload, x_service_token: str | None = Header(None)) -> Response:
     if x_service_token != settings.SERVICE_AUTH_TOKEN:
         raise HTTPException(status_code=401, detail="Unauthorized")
     twiml = build_initial_twiml(payload.dict())
     return Response(content=twiml, media_type="application/xml")
 
+
 @router.post("/transcribe")
-async def transcribe(request: Request):
-    form = await request.form()
-    twiml = build_transcribe_twiml(dict(form))
+async def transcribe(request: Request) -> Response:
+    form = await validate_twilio_request(request)
+    twiml = build_transcribe_twiml(form)
     return Response(content=twiml, media_type="application/xml")
 
+
 @router.post("/partial")
-async def partial(request: Request):
+async def partial(request: Request) -> JSONResponse:
     # Receives partial ASR results from Twilio if PUBLIC_BASE_URL is set
-    data = await request.form()
+    await validate_twilio_request(request)
     return JSONResponse({"ok": True})
+


### PR DESCRIPTION
## Summary
- require a Twilio auth token in settings
- validate incoming webhook signatures using `RequestValidator`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ba7d3ff104833198b531c28d0c61ff