### PR TITLE
Rename service to swift-python-service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SWIFT Voice Service — Barge‑in Ready
+# SWIFT Python Service — Barge‑in Ready
 
 Twilio `<Gather input="speech dtmf" bargeIn="true">` with optional partial ASR callbacks.
 
@@ -6,6 +6,6 @@ Twilio `<Gather input="speech dtmf" bargeIn="true">` with optional partial ASR c
 ```bash
 cp .env.local.example .env.local.local
 docker compose up -d
-docker compose logs -f voice
+docker compose logs -f swift-python-service
 curl http://127.0.0.1:8001/health
 ```

--- a/app/services/call_flow.py
+++ b/app/services/call_flow.py
@@ -24,7 +24,7 @@ def build_initial_twiml(payload: dict) -> str:
 
     gather = response.gather(**gather_kwargs)
     gather.say(
-        "Welcome to SWIFT Voice. You can interrupt me at any time. What do you need?",
+        "Welcome to SWIFT Python. You can interrupt me at any time. What do you need?",
         voice="Polly.Matthew",
     )
     response.say("I did not catch that. Goodbye.", voice="Polly.Matthew")

--- a/app/services/tts_polly.py
+++ b/app/services/tts_polly.py
@@ -4,17 +4,12 @@ from fastapi import WebSocket
 
 
 async def synthesize_and_stream_audio(stream: Iterable[bytes], websocket: WebSocket) -> None:
-    """Stream base64 encoded audio chunks to a websocket sequentially.
-
-    Args:
-        stream: Iterable yielding raw audio bytes.
-        websocket: WebSocket connection to send data through.
-    """
+    """Stream base64 encoded audio chunks to a websocket sequentially."""
     for chunk in stream:
         b64_chunk = base64.b64encode(chunk).decode("ascii")
         await websocket.send_text(b64_chunk)
 
 
 async def handle_stream_session(stream: Iterable[bytes], websocket: WebSocket) -> None:
-    """Handle a websocket session by streaming audio chunks."""
+    """swift-python-service WebSocket session handler."""
     await synthesize_and_stream_audio(stream, websocket)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
-  voice:
+  swift-python-service:
+    container_name: swift-python-service
     build: .
     working_dir: /app
     command: uvicorn main:app --host 0.0.0.0 --port 8001 --reload
@@ -9,3 +10,4 @@ services:
     ports:
       - "127.0.0.1:8001:8001"
     restart: unless-stopped
+

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ from app.routes.http import router as http_router
 from app.routes.sms_handler import router as sms_router
 
 setup_logging()
-app = FastAPI(title="SWIFT Voice Service — Barge-In Ready")
+app = FastAPI(title="SWIFT Python Service — Barge-In Ready")
 app.add_middleware(RequestIdMiddleware)
 app.include_router(http_router)
 app.include_router(sms_router)


### PR DESCRIPTION
## Summary
- rename service and container to `swift-python-service`
- update project references from swift-voice-service to swift-python-service
- adjust documentation and call flow messaging

## Testing
- `TWILIO_AUTH_TOKEN=test pytest -q`
- `rg 'swift-voice-service'`
- `rg 'swift_voice_service'`

------
https://chatgpt.com/codex/tasks/task_e_68bb1d28ae908331a3d52e97c8cebcd6