### PR TITLE
Remove duplicate transcribe handler

### DIFF
--- a/app/routes/http.py
+++ b/app/routes/http.py
@@ -39,13 +39,8 @@ def process_call(payload: CallPayload, x_service_token: str | None = Header(None
 
 
 @router.post("/transcribe")
-
 async def transcribe(request: Request) -> Response:
     form = await validate_twilio_request(request)
-    twiml = build_transcribe_twiml(form)
-
-async def transcribe(request: Request):
-    form = await request.form()
 
     # Prefer transcribing any uploaded audio ourselves using an in-memory buffer
     # rather than persisting to a temporary file on disk.


### PR DESCRIPTION
## Summary
- remove redundant transcribe endpoint implementation
- validate Twilio requests before processing audio

## Testing
- `TWILIO_AUTH_TOKEN=test SERVICE_AUTH_TOKEN=test-token pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc920383408331a6fe2225e46c1f96