### PR TITLE
Fix settings env file path

### DIFF
--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -8,6 +8,6 @@ class Settings(BaseSettings):
     ENV: str = "local"
     PUBLIC_BASE_URL: str | None = None
 
-    model_config = SettingsConfigDict(env_file=".env.local.local", env_file_encoding="utf-8")
+    model_config = SettingsConfigDict(env_file=".env.local", env_file_encoding="utf-8")
 
 settings = Settings()


### PR DESCRIPTION
## Summary
- point settings to `.env.local` for environment variable loading

## Testing
- `python - <<'PY'\nfrom app.core.settings import settings\nprint('SERVICE_AUTH_TOKEN:', settings.SERVICE_AUTH_TOKEN)\nPY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc9206a2f48331ad03b67829d1a826