### PR TITLE
Return 401 for invalid Twilio signatures

### DIFF
--- a/app/routes/http.py
+++ b/app/routes/http.py
@@ -13,10 +13,10 @@ validator = RequestValidator(settings.TWILIO_AUTH_TOKEN)
 
 
 async def validate_twilio_request(request: Request) -> dict:
-    signature = request.headers.get("X-Twilio-Signature", "")
+    signature = request.headers.get("X-Twilio-Signature")
     form = await request.form()
-    if not validator.validate(str(request.url), dict(form), signature):
-        raise HTTPException(status_code=403, detail="Invalid Twilio signature")
+    if not signature or not validator.validate(str(request.url), dict(form), signature):
+        raise HTTPException(status_code=401, detail="Invalid Twilio signature")
     return dict(form)
 
 
@@ -34,7 +34,7 @@ def ready() -> dict:
 def process_call(payload: CallPayload, x_service_token: str | None = Header(None)) -> Response:
     if x_service_token != settings.SERVICE_AUTH_TOKEN:
         raise HTTPException(status_code=401, detail="Unauthorized")
-    twiml = build_initial_twiml(payload.dict())
+    twiml = build_initial_twiml(payload.model_dump())
     return Response(content=twiml, media_type="application/xml")
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,5 @@ structlog
 faster-whisper
 
 twilio>=8.0.0
+python-multipart
 

--- a/tests/test_transcribe_auth.py
+++ b/tests/test_transcribe_auth.py
@@ -1,0 +1,31 @@
+import os
+import sys
+
+from fastapi.testclient import TestClient
+from twilio.request_validator import RequestValidator
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+os.environ.setdefault("SERVICE_AUTH_TOKEN", "test-token")
+os.environ.setdefault("TWILIO_AUTH_TOKEN", "test-twilio-token")
+
+from main import app
+
+client = TestClient(app)
+
+
+def test_transcribe_without_signature_returns_401():
+    response = client.post("/transcribe", data={"SpeechResult": "hello"})
+    assert response.status_code == 401
+
+
+def test_transcribe_with_valid_signature_returns_200():
+    validator = RequestValidator(os.environ["TWILIO_AUTH_TOKEN"])
+    url = str(client.base_url) + "/transcribe"
+    data = {"SpeechResult": "hello"}
+    signature = validator.compute_signature(url, data)
+    response = client.post(
+        "/transcribe",
+        data=data,
+        headers={"X-Twilio-Signature": signature},
+    )
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary
- ensure Twilio request validation returns 401 when signature missing or invalid
- add tests covering `/transcribe` authentication
- include python-multipart dependency for form parsing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcb059e3ec83319e023a9f7fde585d