### PR TITLE
feat: separate voice and sms auth tokens

### DIFF
--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -3,6 +3,8 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class Settings(BaseSettings):
     SERVICE_AUTH_TOKEN: str
     TWILIO_AUTH_TOKEN: str
+    PYTHON_VOICE_TOKEN: str
+    PYTHON_SMS_TOKEN: str
     OPENAI_API_KEY: str | None = None
     REDIS_URL: str = "redis://localhost:6379/0"
     ENV: str = "local"

--- a/app/routes/http.py
+++ b/app/routes/http.py
@@ -32,7 +32,7 @@ def ready() -> dict:
 
 @router.post("/process-call")
 def process_call(payload: CallPayload, x_service_token: str | None = Header(None)) -> Response:
-    if x_service_token != settings.SERVICE_AUTH_TOKEN:
+    if x_service_token != settings.PYTHON_VOICE_TOKEN:
         raise HTTPException(status_code=401, detail="Unauthorized")
     twiml = build_initial_twiml(payload.model_dump())
     return Response(content=twiml, media_type="application/xml")

--- a/app/routes/sms_handler.py
+++ b/app/routes/sms_handler.py
@@ -7,7 +7,7 @@ router = APIRouter()
 @router.post("/sms")
 def sms_handler(x_service_token: str | None = Header(None)) -> Response:
     """Handle incoming SMS webhooks from Twilio."""
-    if x_service_token != settings.SERVICE_AUTH_TOKEN:
+    if x_service_token != settings.PYTHON_SMS_TOKEN:
         raise HTTPException(status_code=401, detail="Unauthorized")
     twiml_response = "<Response><Message>Hello from Swift!</Message></Response>"
     return Response(content=twiml_response, media_type="application/xml")

--- a/tests/test_process_call_auth.py
+++ b/tests/test_process_call_auth.py
@@ -9,6 +9,8 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 # Ensure required environment variables are set for settings
 os.environ.setdefault("SERVICE_AUTH_TOKEN", "test-token")
 os.environ.setdefault("TWILIO_AUTH_TOKEN", "test-twilio-token")
+os.environ.setdefault("PYTHON_VOICE_TOKEN", "test-voice-token")
+os.environ.setdefault("PYTHON_SMS_TOKEN", "test-sms-token")
 
 from main import app
 
@@ -21,6 +23,6 @@ def test_process_call_without_token_returns_401():
 
 
 def test_process_call_with_token_returns_200():
-    token = os.environ["SERVICE_AUTH_TOKEN"]
+    token = os.environ["PYTHON_VOICE_TOKEN"]
     response = client.post("/process-call", headers={"X-Service-Token": token}, json={})
     assert response.status_code == 200

--- a/tests/test_process_sms_auth.py
+++ b/tests/test_process_sms_auth.py
@@ -6,6 +6,8 @@ from fastapi.testclient import TestClient
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 os.environ.setdefault("SERVICE_AUTH_TOKEN", "test-token")
 os.environ.setdefault("TWILIO_AUTH_TOKEN", "test-twilio-token")
+os.environ.setdefault("PYTHON_VOICE_TOKEN", "test-voice-token")
+os.environ.setdefault("PYTHON_SMS_TOKEN", "test-sms-token")
 
 from main import app
 
@@ -18,6 +20,6 @@ def test_sms_without_token_returns_401():
 
 
 def test_sms_with_token_returns_200():
-    token = os.environ["SERVICE_AUTH_TOKEN"]
+    token = os.environ["PYTHON_SMS_TOKEN"]
     response = client.post("/sms", headers={"X-Service-Token": token})
     assert response.status_code == 200

--- a/tests/test_sms_handler.py
+++ b/tests/test_sms_handler.py
@@ -6,6 +6,8 @@ from fastapi.testclient import TestClient
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 os.environ.setdefault("SERVICE_AUTH_TOKEN", "test-token")
 os.environ.setdefault("TWILIO_AUTH_TOKEN", "test-twilio-token")
+os.environ.setdefault("PYTHON_VOICE_TOKEN", "test-voice-token")
+os.environ.setdefault("PYTHON_SMS_TOKEN", "test-sms-token")
 
 from main import app
 
@@ -13,7 +15,7 @@ client = TestClient(app)
 
 
 def test_sms_route_returns_twiml():
-    token = os.environ["SERVICE_AUTH_TOKEN"]
+    token = os.environ["PYTHON_SMS_TOKEN"]
     response = client.post("/sms", headers={"X-Service-Token": token})
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("application/xml")

--- a/tests/test_transcribe_auth.py
+++ b/tests/test_transcribe_auth.py
@@ -7,6 +7,8 @@ from twilio.request_validator import RequestValidator
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 os.environ.setdefault("SERVICE_AUTH_TOKEN", "test-token")
 os.environ.setdefault("TWILIO_AUTH_TOKEN", "test-twilio-token")
+os.environ.setdefault("PYTHON_VOICE_TOKEN", "test-voice-token")
+os.environ.setdefault("PYTHON_SMS_TOKEN", "test-sms-token")
 
 from main import app
 


### PR DESCRIPTION
## Summary
- add `PYTHON_VOICE_TOKEN` and `PYTHON_SMS_TOKEN` settings
- require matching tokens for `/process-call` and `/sms` endpoints
- extend tests to provide and validate the new tokens

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c05b30db4c8331bb27609e0880bbaa