### PR TITLE
Add Twilio token setting

### DIFF
--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -4,6 +4,7 @@ class Settings(BaseSettings):
     SERVICE_AUTH_TOKEN: str
 
     TWILIO_SID: str
+    TWILIO_TOKEN: str
 
     PYTHON_VOICE_TOKEN: str
     PYTHON_SMS_TOKEN: str


### PR DESCRIPTION
## Summary
- declare required TWILIO_TOKEN in Settings
- instantiate settings object to load new field from environment

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c061a2fa2883319770fc12271ecba7