### PR TITLE
Remove unused SERVICE_AUTH_TOKEN and add missing Twilio token setting

### DIFF
--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -1,9 +1,8 @@
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Settings(BaseSettings):
-    SERVICE_AUTH_TOKEN: str
-
     TWILIO_SID: str
+    TWILIO_TOKEN: str
 
     PYTHON_VOICE_TOKEN: str
     PYTHON_SMS_TOKEN: str

--- a/tests/test_process_call_auth.py
+++ b/tests/test_process_call_auth.py
@@ -7,8 +7,6 @@ from fastapi.testclient import TestClient
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 # Ensure required environment variables are set for settings
-os.environ.setdefault("SERVICE_AUTH_TOKEN", "test-token")
-
 os.environ.setdefault("TWILIO_SID", "test-twilio-sid")
 os.environ.setdefault("TWILIO_TOKEN", "test-twilio-token")
 

--- a/tests/test_process_sms_auth.py
+++ b/tests/test_process_sms_auth.py
@@ -4,7 +4,6 @@ import sys
 from fastapi.testclient import TestClient
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-os.environ.setdefault("SERVICE_AUTH_TOKEN", "test-token")
 
 os.environ.setdefault("TWILIO_SID", "test-twilio-sid")
 os.environ.setdefault("TWILIO_TOKEN", "test-twilio-token")

--- a/tests/test_sms_handler.py
+++ b/tests/test_sms_handler.py
@@ -4,7 +4,6 @@ import sys
 from fastapi.testclient import TestClient
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-os.environ.setdefault("SERVICE_AUTH_TOKEN", "test-token")
 
 os.environ.setdefault("TWILIO_SID", "test-twilio-sid")
 os.environ.setdefault("TWILIO_TOKEN", "test-twilio-token")

--- a/tests/test_transcribe_auth.py
+++ b/tests/test_transcribe_auth.py
@@ -5,7 +5,6 @@ from fastapi.testclient import TestClient
 from twilio.request_validator import RequestValidator
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-os.environ.setdefault("SERVICE_AUTH_TOKEN", "test-token")
 
 os.environ.setdefault("TWILIO_SID", "test-twilio-sid")
 os.environ.setdefault("TWILIO_TOKEN", "test-twilio-token")


### PR DESCRIPTION
## Summary
- remove unused SERVICE_AUTH_TOKEN configuration
- add missing TWILIO_TOKEN setting
- adjust tests to drop unused environment variable

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c061a408048331b9dc0cb5e64b3414