### PR TITLE
Refactor CallPayload to use snake_case fields

### DIFF
--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -4,6 +4,7 @@ class Settings(BaseSettings):
     SERVICE_AUTH_TOKEN: str
 
     TWILIO_SID: str
+    TWILIO_TOKEN: str
 
     PYTHON_VOICE_TOKEN: str
     PYTHON_SMS_TOKEN: str

--- a/app/models/call.py
+++ b/app/models/call.py
@@ -1,6 +1,13 @@
-from pydantic import BaseModel
+"""Models for call-related payloads."""
+
+from pydantic import BaseModel, Field
+
+
 class CallPayload(BaseModel):
-    From: str | None = None
-    To: str | None = None
-    CallSid: str | None = None
-    SpeechResult: str | None = None
+    """Payload sent by Twilio during voice interactions."""
+
+    from_: str | None = Field(None, alias="From")
+    to: str | None = Field(None, alias="To")
+    call_sid: str | None = Field(None, alias="CallSid")
+    speech_result: str | None = Field(None, alias="SpeechResult")
+

--- a/app/routes/http.py
+++ b/app/routes/http.py
@@ -53,7 +53,7 @@ async def transcribe(request: Request) -> Response:
         data = await audio.read() if hasattr(audio, "read") else audio
         text = transcribe_audio(data)
 
-    twiml = build_transcribe_twiml({"SpeechResult": text})
+    twiml = build_transcribe_twiml({"speech_result": text})
 
     return Response(content=twiml, media_type="application/xml")
 

--- a/app/services/call_flow.py
+++ b/app/services/call_flow.py
@@ -4,7 +4,7 @@ from twilio.twiml.voice_response import VoiceResponse
 
 
 def build_initial_twiml(payload: dict) -> str:
-    sid = payload.get("CallSid") or ""
+    sid = payload.get("call_sid") or ""
     set_state(sid, stage="gather")
 
     base = settings.PUBLIC_BASE_URL or ""
@@ -32,7 +32,7 @@ def build_initial_twiml(payload: dict) -> str:
 
 
 def build_transcribe_twiml(payload: dict) -> str:
-    text = payload.get("SpeechResult") or ""
+    text = payload.get("speech_result") or ""
     response = VoiceResponse()
     response.say(f"You said: {text}", voice="Polly.Matthew")
     response.hangup()


### PR DESCRIPTION
## Summary
- model `CallPayload` using snake_case attributes with Twilio-compatible aliases
- update call flow and HTTP handlers to reference new field names
- add `TWILIO_TOKEN` to settings for request validation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c061a613708331ad2464d36b2ca5cb