### PR TITLE
Ignore extra environment variables in Settings

### DIFF
--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -12,6 +12,6 @@ class Settings(BaseSettings):
     ENV: str = "local"
     PUBLIC_BASE_URL: str | None = None
 
-    model_config = SettingsConfigDict(env_file=".env.local", env_file_encoding="utf-8")
+    model_config = SettingsConfigDict(env_file=".env.local", env_file_encoding="utf-8", extra="ignore")
 
 settings = Settings()


### PR DESCRIPTION
## Summary
- ignore extraneous env values in Pydantic Settings

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1a3f250fc83318ab4cc1b932b1d34