### PR TITLE
Refactor request ID logging filter

### DIFF
--- a/app/middleware/request_id.py
+++ b/app/middleware/request_id.py
@@ -1,10 +1,36 @@
+import contextvars
+import logging
+import uuid
+
 from starlette.middleware.base import BaseHTTPMiddleware
-import uuid, logging
+
+
+# Context variable to store the current request ID
+_request_id_ctx: contextvars.ContextVar[str] = contextvars.ContextVar("request_id", default="")
+
+
+class RequestIdFilter(logging.Filter):
+    """Logging filter that injects the current request ID into log records."""
+
+    def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - trivial
+        record.request_id = _request_id_ctx.get()
+        return True
+
+
+# Attach the filter once to the root logger
+_root_logger = logging.getLogger()
+if not any(isinstance(f, RequestIdFilter) for f in _root_logger.filters):
+    _root_logger.addFilter(RequestIdFilter())
+
+
 class RequestIdMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request, call_next):
         rid = request.headers.get("X-Request-ID", str(uuid.uuid4()))
-        for h in logging.getLogger().handlers:
-            h.addFilter(lambda rec: setattr(rec, "request_id", rid) or True)
-        resp = await call_next(request)
+        token = _request_id_ctx.set(rid)
+        try:
+            resp = await call_next(request)
+        finally:
+            _request_id_ctx.reset(token)
         resp.headers["X-Request-ID"] = rid
         return resp
+


### PR DESCRIPTION
## Summary
- replace per-request lambda filter with reusable RequestIdFilter based on contextvars
- attach filter once to root logger and manage request ID per request in middleware

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1a3f360f88331bdaba0f723936a7b